### PR TITLE
Issue 3 adjustments to home page

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -221,8 +221,6 @@ body {
 }
 
 .crop-container {
-  width: 200px;  /* desired width */
-  height: 200px; /* desired height */
   overflow: hidden; /* hide overflow to create the crop effect */
   position: relative;
 }

--- a/css/typography.css
+++ b/css/typography.css
@@ -30,12 +30,16 @@ body {
 .body-text {
   font-size: 16px;
   font-weight: 500;
-  min-height: 6rem;
+}
+
+.body-text-no-min-height {
+  font-size: 16px;
+  font-weight: 500;
 }
 
 .project-card-text {
   overflow: hidden;
-  /* text-overflow: ellipsis;     / */
+  text-overflow: ellipsis;     /
   display: -webkit-box;
   -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -59,7 +59,7 @@ a.icon-link:hover {
 
 a.button {
   padding: 8px 16px;
-  border: 3px solid #141414;
+  border: 1px solid #141414;
   border-radius: 50px;
   color: black;
   text-decoration: none;

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
         <div id="portfolio-header-text-container">
             <div class="header-text">
               <span class="main-title">Hi, I'm Tori Charnetzki.</span>
-              <div class="body-text">I've worked on and around film sets since 2017. I'd love to help you make your next visual project.</div>
+              <div class="body-text-no-min-height">I've worked on and around film sets since 2017. I'd love to help you make your next visual project.</div>
             </div>
             <a class="button" id="my-work-link">
               <span class="button-text">Check out my projects</span> 


### PR DESCRIPTION
Closes #3 

- fixes headshot sizing
- removes min-height from body text 
  - this fixes the big gap above buttons, but also means the project descriptions should be about equal length in number of words if you want the "Read More" buttons to line up
- I don't know what the "wonky project icon movement" part of the issue is, so consider it not fixed. 